### PR TITLE
[Fix] Fixing the GH action to deploy docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,8 +16,14 @@ jobs:
         - name: Install uv
           uses: astral-sh/setup-uv@v3
 
+        - name: Git Config bot
+          run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+
         - name: Set up Python
           run: uv python install
+
+        - name: Build Documentation
+          run: uv run mkdocs build
         
         - name: Deploy Documentation
           run: uv run mkdocs gh-deploy


### PR DESCRIPTION
Simple fix of the GH action to deploy the docs by adding a git config for the git account bot and building before deploying