### PR TITLE
Update: Incresement of the timeouts from 120 to 180 seconds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthgenai"
-version = "2.0.1"
+version = "2.0.2"
 description = "SynthGenAI - Package for generating Synthetic Datasets."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/synthgenai/llm/llm.py
+++ b/synthgenai/llm/llm.py
@@ -278,7 +278,7 @@ class LLM(BaseLLM):
                 max_tokens=self.max_tokens,
                 api_base=self.api_base,
                 api_key=self.api_key,
-                timeout=120,
+                timeout=180,
             )
             logger.info(f"Successfully generated completion using model: {self.model}")
             model_response = response.choices[0].message.content
@@ -312,7 +312,7 @@ class LLM(BaseLLM):
                 max_tokens=self.max_tokens,
                 api_base=self.api_base,
                 api_key=self.api_key,
-                timeout=120,
+                timeout=180,
             )
             model_response = response.choices[0].message.content
             logger.info(f"Successfully generated async completion using: {self.model}")


### PR DESCRIPTION
This pull request makes a minor adjustment to the timeout settings for both synchronous and asynchronous model generation in the `synthgenai/llm/llm.py` file. The timeout has been increased from 120 seconds to 180 seconds to allow more time for completion responses.